### PR TITLE
add merge flag for deploy command

### DIFF
--- a/.changeset/hot-deer-dance.md
+++ b/.changeset/hot-deer-dance.md
@@ -2,4 +2,4 @@
 "@vahor/n8n-kit-cli": patch
 ---
 
-Add `--merge` option in deploy command to preserve n8n node position during deploy.
+Add a `--merge` option to the deploy command to preserve n8n node positions during deployment (enabled by default; pass `--no-merge` to disable).

--- a/.changeset/hot-deer-dance.md
+++ b/.changeset/hot-deer-dance.md
@@ -1,0 +1,5 @@
+---
+"@vahor/n8n-kit-cli": patch
+---
+
+Add `--merge` option in deploy command to preserve n8n node position during deploy.

--- a/README.md
+++ b/README.md
@@ -105,7 +105,8 @@ export { app };
 
 - **Generated Graph Layout**: 
 	- No mid-graph direction changes.
-    - No way to set node execution priority (n8n runs nodes top-to-bottom)
+	- No way to set node execution priority (n8n runs nodes top-to-bottom)
+	- **Workaround**: Deploy the workflow once, then edit the workflow in n8n. With the `--merge` option, the nodes positions won't be overwritten.
 - **Credentials**: Must be defined in n8n first, then referenced via `Credentials.byId()` (no API endpoint available)
 - **Folders**: Workflows deploy to root; manual folder organization required (no API endpoint available). You can still organize them manually once deployed.
 

--- a/README.md
+++ b/README.md
@@ -105,8 +105,8 @@ export { app };
 
 - **Generated Graph Layout**: 
 	- No mid-graph direction changes.
-	- No way to set node execution priority (n8n runs nodes top-to-bottom)
-	- **Workaround**: Deploy the workflow once, then edit the workflow in n8n. With the `--merge` option, the nodes positions won't be overwritten.
+  - No way to set node execution priority (n8n runs nodes top-to-bottom)
+  - **Workaround**: Deploy the workflow once, then edit the workflow in n8n. With the `--merge` option, node positions won't be overwritten.
 - **Credentials**: Must be defined in n8n first, then referenced via `Credentials.byId()` (no API endpoint available)
 - **Folders**: Workflows deploy to root; manual folder organization required (no API endpoint available). You can still organize them manually once deployed.
 

--- a/packages/n8n-cli/README.md
+++ b/packages/n8n-cli/README.md
@@ -114,6 +114,9 @@ Deploy your workflows to n8n.
 bunx @vahor/n8n deploy [options]
 ```
 
+**Options:**
+- `--merge` - Do not overwrite nodes position in existing workflows (default: true)
+
 **Workflow Matching:**
 
 - Workflows are matched by a unique tag generated from their hash ID


### PR DESCRIPTION
fix: https://github.com/Vahor/n8n-kit/issues/12

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Deploy now supports a --merge option (enabled by default) to preserve existing node positions in n8n workflows.

* **Documentation**
  * Updated CLI deploy command docs to include the --merge flag and its behavior.
  * Added guidance under Generated Graph Layout: deploy once, then edit in n8n; with --merge, positions aren’t overwritten.

* **Chores**
  * Added patch release note describing the new --merge option.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->