### PR TITLE
Replace references of workflow ids during deployment

### DIFF
--- a/.changeset/evil-islands-eat.md
+++ b/.changeset/evil-islands-eat.md
@@ -1,0 +1,6 @@
+---
+"@vahor/n8n-kit-cli": patch
+"@vahor/n8n-kit": patch
+---
+
+Replace references of workflow ids during deployment

--- a/packages/n8n-cli/src/n8n-api.ts
+++ b/packages/n8n-cli/src/n8n-api.ts
@@ -48,21 +48,23 @@ export class N8nApi {
 	}
 
 	async createWorkflow(
-		input: Omit<WorkflowDefinition, "id" | "tags" | "active">,
+		// input: Omit<WorkflowDefinition, "id" | "tags" | "active">,
+		input: string,
 	): Promise<WorkflowDefinition> {
 		return this.request("/api/v1/workflows", {
 			method: "POST",
-			body: JSON.stringify(input),
+			body: input,
 		});
 	}
 
 	async updateWorkflow(
 		id: string,
-		input: Omit<WorkflowDefinition, "id" | "tags" | "active">,
+		// input: Omit<WorkflowDefinition, "id" | "tags" | "active">
+		input: string,
 	) {
 		return this.request(`/api/v1/workflows/${id}`, {
 			method: "PUT",
-			body: JSON.stringify(input),
+			body: input,
 		});
 	}
 

--- a/packages/n8n-kit/src/nodes/execute-workflow.ts
+++ b/packages/n8n-kit/src/nodes/execute-workflow.ts
@@ -1,7 +1,7 @@
 import type { Type } from "arktype";
 import type { ExecuteWorkflowNodeParameters } from "../generated/nodes/ExecuteWorkflow";
 import { ExecuteWorkflow as _ExecuteWorkflow } from "../generated/nodes-impl/ExecuteWorkflow";
-import type { Workflow } from "../workflow";
+import { RESOLVED_WORKFLOW_ID, type Workflow } from "../workflow";
 import type { NodeProps } from "./node";
 
 export interface ExecuteWorkflowProps<Input extends Type, Output extends Type>
@@ -33,7 +33,7 @@ export class ExecuteWorkflow<
 			// @ts-expect-error: remove workflow from output as it's onlu used for the workflowId
 			workflow: undefined,
 			workflowId: {
-				value: this.props.parameters.workflow.id,
+				value: RESOLVED_WORKFLOW_ID(this.props.parameters.workflow.id),
 				mode: "list",
 				cachedResultName: this.props.parameters.workflow.id,
 			},

--- a/packages/n8n-kit/src/workflow/workflow.ts
+++ b/packages/n8n-kit/src/workflow/workflow.ts
@@ -274,3 +274,6 @@ export class Workflow<Input extends Type = any, Output extends Type = any> {
 export type WorkflowDefinition = ReturnType<Workflow["build"]>;
 
 export const workflowTagId = (id: string) => `${prefix}${id}`;
+export const RESOLVED_WORKFLOW_ID_PREFIX = `${prefix}_resolved_workflow_id@`;
+export const RESOLVED_WORKFLOW_ID = (workflowId: string) =>
+	`${RESOLVED_WORKFLOW_ID_PREFIX}${workflowId}`;


### PR DESCRIPTION
fix: https://github.com/Vahor/n8n-kit/issues/31

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Deployment now auto-resolves workflow references, preventing broken links between workflows.
  - Fails fast with clear errors when unresolved references remain.
  - Improved verbose logging during deployment for easier troubleshooting.
  - Execute Workflow node uses resolved IDs for more reliable linking.
  - Ensures consistent linking after create/update operations during deploys.

- Chores
  - Patch releases for @vahor/n8n-kit-cli and @vahor/n8n-kit.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->