### PR TITLE
preserve Context and Ids passed through true/false in if node

### DIFF
--- a/.changeset/curly-flies-tap.md
+++ b/.changeset/curly-flies-tap.md
@@ -1,0 +1,5 @@
+---
+"@vahor/n8n-kit": patch
+---
+
+Add node clone method - keeping type

--- a/.changeset/free-ravens-follow.md
+++ b/.changeset/free-ravens-follow.md
@@ -1,0 +1,5 @@
+---
+"@vahor/n8n-kit": patch
+---
+
+preserve Context and Ids passed through true/false in if node

--- a/bun.lock
+++ b/bun.lock
@@ -76,10 +76,12 @@
       "dependencies": {
         "@dagrejs/dagre": "^1.1.5",
         "arktype": "catalog:",
+        "lodash.clonedeep": "^4.5.0",
         "slugify": "^1.6.6",
       },
       "devDependencies": {
         "@n8n/n8n-nodes-langchain": "1.107.0",
+        "@types/lodash.clonedeep": "^4.5.9",
         "cheerio": "1.0.0-rc.6",
         "codemaker": "^1.113.0",
         "eventsource": "2.0.2",
@@ -89,6 +91,11 @@
         "typescript": "catalog:",
       },
     },
+  },
+  "catalog": {
+    "arktype": "^2.1.20",
+    "tsdown": "^0.14.1",
+    "typescript": "^5.9.2",
   },
   "packages": {
     "@actions/core": ["@actions/core@1.11.1", "", { "dependencies": { "@actions/exec": "^1.1.1", "@actions/http-client": "^2.0.1" } }, "sha512-hXJCSrkwfA46Vd9Z3q4cpEpHB1rL5NG04+/rbqW9d3+CSvtB1tYe8UTpAlixa1vj0m/ULglfEK2UKxMGxCxv5A=="],
@@ -878,6 +885,8 @@
     "@types/es-aggregate-error": ["@types/es-aggregate-error@1.0.6", "", { "dependencies": { "@types/node": "*" } }, "sha512-qJ7LIFp06h1QE1aVxbVd+zJP2wdaugYXYfd6JxsyRMrYHaxb6itXPogW2tz+ylUJ1n1b+JF1PHyYCfYHm0dvUg=="],
 
     "@types/lodash": ["@types/lodash@4.17.20", "", {}, "sha512-H3MHACvFUEiujabxhaI/ImO6gUrd8oOurg7LQtS7mbwIXA/cUqWrvBsaeJ23aZEPk1TAYkurjfMbSELfoCXlGA=="],
+
+    "@types/lodash.clonedeep": ["@types/lodash.clonedeep@4.5.9", "", { "dependencies": { "@types/lodash": "*" } }, "sha512-19429mWC+FyaAhOLzsS8kZUsI+/GmBAQ0HFiCPsKGU+7pBXOQWhyrY6xNNDwUSX8SMZMJvuFVMF9O5dQOlQK9Q=="],
 
     "@types/long": ["@types/long@4.0.2", "", {}, "sha512-MqTGEo5bj5t157U6fA/BiDynNkn0YknVdh48CMPkTSpFTVmvao5UQmm7uEF6xBEo7qIMAlY/JSleYaE6VOdpaA=="],
 
@@ -1796,6 +1805,8 @@
     "lodash-es": ["lodash-es@4.17.21", "", {}, "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw=="],
 
     "lodash.camelcase": ["lodash.camelcase@4.3.0", "", {}, "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA=="],
+
+    "lodash.clonedeep": ["lodash.clonedeep@4.5.0", "", {}, "sha512-H5ZhCF25riFd9uB5UCkVKo61m3S/xZk1x4wA6yp/L3RFP6Z/eHH1ymQcGLo7J3GMPfm0V/7m1tryHuGVxpqEBQ=="],
 
     "lodash.includes": ["lodash.includes@4.3.0", "", {}, "sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w=="],
 

--- a/packages/n8n-kit/package.json
+++ b/packages/n8n-kit/package.json
@@ -93,14 +93,16 @@
 	"dependencies": {
 		"@dagrejs/dagre": "^1.1.5",
 		"arktype": "catalog:",
+		"lodash.clonedeep": "^4.5.0",
 		"slugify": "^1.6.6"
 	},
 	"devDependencies": {
 		"@n8n/n8n-nodes-langchain": "1.107.0",
-		"n8n-core": "1.106.2",
+		"@types/lodash.clonedeep": "^4.5.9",
 		"cheerio": "1.0.0-rc.6",
-		"eventsource": "2.0.2",
 		"codemaker": "^1.113.0",
+		"eventsource": "2.0.2",
+		"n8n-core": "1.106.2",
 		"tinyglobby": "^0.2.14",
 		"tsdown": "catalog:",
 		"typescript": "catalog:"

--- a/packages/n8n-kit/src/nodes/if.ts
+++ b/packages/n8n-kit/src/nodes/if.ts
@@ -105,6 +105,14 @@ export class If<
 		};
 	}
 
+	override canTakeInput(
+		_fromState: IChainable,
+		_withConnectionOptions?: ConnectionOptions,
+	): boolean {
+		// NOTE: this does not prevent calling twice the same method (true().true()), but it prevent calling it more that twice.
+		return this.endStates.length < 2;
+	}
+
 	public true<N extends IChainable>(
 		next: IsNullable<True> extends true
 			? N
@@ -119,6 +127,7 @@ export class If<
 	> {
 		if (typeof next === "string") throw new Error(next);
 		super.addNext(next.startState, { ...connectionOptions, from: 0 });
+		this.endStates = [...this.endStates, ...next.endStates];
 		return this as any;
 	}
 
@@ -136,6 +145,7 @@ export class If<
 	> {
 		if (typeof next === "string") throw new Error(next);
 		super.addNext(next.startState, { ...connectionOptions, from: 1 });
+		this.endStates = [...this.endStates, ...next.endStates];
 		return this as any;
 	}
 }

--- a/packages/n8n-kit/src/nodes/node.ts
+++ b/packages/n8n-kit/src/nodes/node.ts
@@ -1,6 +1,7 @@
 import clone from "lodash.clonedeep";
 import type { Credentials } from "../credentials";
 import { NODE_SYMBOL } from "../symbols";
+import { checkInternalIdentifier } from "../utils/slugify";
 import type { Workflow } from "../workflow";
 import { State } from "../workflow/chain/state";
 import type { IContext, INextable } from "../workflow/chain/types";
@@ -112,6 +113,7 @@ export abstract class Node<
 		id: Id,
 		props?: NodeProps,
 	): Omit<this, "id"> & Node<Id, C> {
+		checkInternalIdentifier(id);
 		const newInstance = clone(this) as unknown as Node<Id, C>;
 		if (props) {
 			// @ts-expect-error: readonly

--- a/packages/n8n-kit/src/utils/slugify.ts
+++ b/packages/n8n-kit/src/utils/slugify.ts
@@ -28,6 +28,7 @@ export const validateIdentifier = <A extends string>(str: A): A => {
 	return slug as A;
 };
 
+// TODO: add tests to check possible collisions
 export function shortHash(text: string, length = 12) {
 	const hash = crypto.createHash("sha256").update(text).digest("base64");
 	return hash.substring(0, length);

--- a/packages/n8n-kit/src/utils/types.ts
+++ b/packages/n8n-kit/src/utils/types.ts
@@ -12,7 +12,11 @@ export type IsRecord<T> = string extends keyof T ? true : false;
 
 export type IsAny<T> = 0 extends 1 & T ? true : false;
 
-export type IsUnknown<T> = unknown extends T ? true : false;
+export type IsUnknown<T> = IsAny<T> extends true
+	? false
+	: unknown extends T
+		? true
+		: false;
 
 export type IsNullable<T> = IsNever<T> extends true
 	? false

--- a/packages/n8n-kit/src/utils/types.ts
+++ b/packages/n8n-kit/src/utils/types.ts
@@ -12,6 +12,8 @@ export type IsRecord<T> = string extends keyof T ? true : false;
 
 export type IsAny<T> = 0 extends 1 & T ? true : false;
 
+export type IsUnknown<T> = unknown extends T ? true : false;
+
 export type IsNullable<T> = IsNever<T> extends true
 	? false
 	: T extends null

--- a/packages/n8n-kit/src/workflow/chain/chain.ts
+++ b/packages/n8n-kit/src/workflow/chain/chain.ts
@@ -31,25 +31,29 @@ export type AddIChainableToChainContext<
 	N,
 	CC extends ChainContext,
 	WithPrevious = true,
-> = N extends Group<infer _, infer G_Chain_CC, any>
-	? IgnoreContext<G_Chain_CC> extends true
-		? Omit<CC, PREVIOUS_CONTENT>
-		: Prettify<Omit<CC, PREVIOUS_CONTENT> & G_Chain_CC>
-	: N extends If<any, any, any, infer I_Chain_CC, any>
-		? IgnoreContext<I_Chain_CC> extends true
+> = Prettify<
+	N extends Chain<infer C_CC, any>
+		? IgnoreContext<C_CC> extends true
 			? Omit<CC, PREVIOUS_CONTENT>
-			: Prettify<Omit<CC & I_Chain_CC, PREVIOUS_CONTENT>>
-		: N extends IChainable<infer Id, infer C>
-			? IgnoreContext<C> extends true
+			: Omit<CC, PREVIOUS_CONTENT> & C_CC
+		: N extends Group<infer _, infer G_Chain_CC, any>
+			? IgnoreContext<G_Chain_CC> extends true
 				? Omit<CC, PREVIOUS_CONTENT>
-				: Prettify<
-						{ [k in Id]: C } & Omit<CC, PREVIOUS_CONTENT> & {
-								[k in PREVIOUS_CONTENT as WithPrevious extends true
-									? k
-									: never]: C;
-							}
-					>
-			: { CC: CC };
+				: Omit<CC, PREVIOUS_CONTENT> & G_Chain_CC
+			: N extends If<any, any, any, infer I_Chain_CC, any>
+				? IgnoreContext<I_Chain_CC> extends true
+					? Omit<CC, PREVIOUS_CONTENT>
+					: Omit<CC & I_Chain_CC, PREVIOUS_CONTENT>
+				: N extends IChainable<infer Id, infer C>
+					? IgnoreContext<C> extends true
+						? Omit<CC, PREVIOUS_CONTENT>
+						: { [k in Id]: C } & Omit<CC, PREVIOUS_CONTENT> & {
+									[k in PREVIOUS_CONTENT as WithPrevious extends true
+										? k
+										: never]: C;
+								}
+					: CC
+>;
 
 export type AddNodeIdToIds<N, Ids extends readonly string[]> = N extends Group<
 	infer _,
@@ -59,9 +63,11 @@ export type AddNodeIdToIds<N, Ids extends readonly string[]> = N extends Group<
 	? [...Ids, ...G_Chain_Ids]
 	: N extends If<any, any, any, any, infer G_Chain_Ids>
 		? [...Ids, ...G_Chain_Ids]
-		: N extends IChainable<infer Id>
-			? [...Ids, Id]
-			: Ids;
+		: N extends Chain<any, infer G_Chain_Ids>
+			? [...Ids, ...G_Chain_Ids]
+			: N extends IChainable<infer Id>
+				? [...Ids, Id]
+				: Ids;
 
 export type ExtractChainContext<C> = C extends Chain<infer CC> ? CC : {};
 
@@ -83,7 +89,7 @@ export class Chain<
 	CC extends ChainContext = {},
 	IdsInContext extends string[] = [],
 	EndsInMultiple = false,
-> implements IChainable
+> implements IChainable<"chain", CC>
 {
 	"~context": CC = undefined as any;
 

--- a/packages/n8n-kit/src/workflow/chain/chain.ts
+++ b/packages/n8n-kit/src/workflow/chain/chain.ts
@@ -6,7 +6,7 @@ import type {
 	IsUnknown,
 	Prettify,
 } from "../../utils/types";
-import { Group } from "../group";
+import type { Group } from "../group";
 import { $$, type ExpressionBuilderProvider } from "./expression-builder";
 import { State } from "./state";
 import type { ConnectionOptions, IChainable, INextable } from "./types";
@@ -92,6 +92,7 @@ export class Chain<
 > implements IChainable<"chain", CC>
 {
 	"~context": CC = undefined as any;
+	readonly id = "chain";
 
 	/**
 	 * Begin a new Chain from one chainable
@@ -116,11 +117,6 @@ export class Chain<
 	}
 
 	/**
-	 * Identify this Chain
-	 */
-	public readonly id: string;
-
-	/**
 	 * The start state of this chain
 	 */
 	public readonly startState: State;
@@ -135,7 +131,6 @@ export class Chain<
 		endStates: INextable[],
 		private readonly lastAdded: IChainable<string>,
 	) {
-		this.id = lastAdded.id;
 		this.startState = startState;
 		this.endStates = endStates;
 	}
@@ -205,17 +200,6 @@ export class Chain<
 
 		for (const endState of this.endStates) {
 			for (const nextState of next) {
-				if (nextState instanceof Group) {
-					const nodes = nextState.chain.toList();
-					if (nodes.length === 0) {
-						throw new Error("Group must have at least one node");
-					}
-					// Add the group just for the sticky layout
-					// TODO: try to add the type here.
-					this.next(nodes[0]! as any);
-					continue;
-				}
-
 				endState.addNext(nextState);
 			}
 		}

--- a/packages/n8n-kit/src/workflow/chain/state.ts
+++ b/packages/n8n-kit/src/workflow/chain/state.ts
@@ -40,14 +40,27 @@ export abstract class State<
 		};
 	}
 
+	public canTakeInput(
+		_fromState: IChainable,
+		_withConnectionOptions?: ConnectionOptions,
+	) {
+		return true;
+	}
+
 	public addNext(state: IChainable, connectionOptions?: ConnectionOptions) {
+		if (!this.canTakeInput(state, connectionOptions)) {
+			throw new Error(
+				`Cannot add '${state.id}' to '${this.id}' because it cannot take more input with ${JSON.stringify(
+					connectionOptions,
+				)}`,
+			);
+		}
+
 		if (isGroup(state)) {
-			const nodes = state.chain.toList();
-			if (nodes.length === 0) {
-				throw new Error("Group must have at least one node");
-			}
-			// Add the group just for the sticky layout
-			this.addNext(nodes[0]!, connectionOptions);
+			const nodes = state.endStates;
+			// TODO: we should probably add checks
+			const firstNode = nodes.at(0)! as unknown as IChainable;
+			this.addNext(firstNode, connectionOptions);
 			return;
 		}
 

--- a/packages/n8n-kit/src/workflow/group/group.ts
+++ b/packages/n8n-kit/src/workflow/group/group.ts
@@ -19,8 +19,6 @@ export class Group<
 	static readonly [GROUP_SYMBOL] = true;
 	readonly [GROUP_SYMBOL] = true;
 
-	private readonly nodesInChain: State[] = [];
-
 	constructor(
 		workflow: Workflow,
 		id: LiteralId,
@@ -38,16 +36,18 @@ export class Group<
 			},
 		});
 		workflow.addToDynamicalyAddedNodes(this);
-		this.endStates = [this];
-		this.nodesInChain = this.chain.toList();
+		this.endStates = this.chain.toList();
+		if (this.endStates.length === 0) {
+			throw new Error("Group must have at least one node");
+		}
 	}
 
 	override "~validate"(): void {
-		const nodes = this.nodesInChain;
+		const nodes = this.endStates;
 		for (let i = 0; i < nodes.length; i++) {
 			const node = nodes[i]!;
-			if (this._props.filterNodes?.(node, i) === false) continue;
 			if (isNode(node)) {
+				if (this._props.filterNodes?.(node, i) === false) continue;
 				node["~setGroup"](this.id);
 			}
 		}

--- a/packages/n8n-kit/tests/nodes/if.test.ts
+++ b/packages/n8n-kit/tests/nodes/if.test.ts
@@ -128,6 +128,24 @@ describe("If", () => {
 			});
 		});
 
+		test("preserve id and context even when connecting to another chain", () => {
+			const chain = Chain.start(new NoOp("start")).next(
+				// Only checking true as we've seen that other cases
+				// correctly infer the ids and context
+				baseifNode.true(trueNodeChain),
+			);
+			type ChainContext = typeof chain extends Chain<infer _> ? _ : never;
+			type ExpectedContext = trueNodeInContext;
+			expectTypeOf<ChainContext>().toEqualTypeOf<ExpectedContext>();
+
+			type IdsInChain = typeof chain extends Chain<any, infer Ids>
+				? Ids
+				: never;
+			expectTypeOf<IdsInChain>().toEqualTypeOf<
+				["start", "true", "something", "end"]
+			>();
+		});
+
 		test("can connect to if true/false nodes", () => {
 			Chain.start(new NoOp("start"))
 				.next(baseifNode.true(trueNode).false(falseNode))


### PR DESCRIPTION
fix: https://github.com/Vahor/n8n-kit/issues/14

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added ability to deep-clone nodes with a new clone method.
  - If node now preserves context and node IDs across true/false branches for smoother chaining, with clearer errors when exceeding two inputs.

- Refactor
  - Improved workflow chaining consistency, context propagation, and ID accumulation across Chain/Group/If.
  - Enhanced input validation in state transitions and group handling.

- Tests
  - Expanded coverage for If chaining, context/ID propagation, and invalid connections.

- Chores
  - Added lodash.clonedeep as a runtime dependency and its type definitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->