### PR TITLE
fields - check type in output

### DIFF
--- a/.changeset/public-seals-battle.md
+++ b/.changeset/public-seals-battle.md
@@ -1,0 +1,7 @@
+---
+"@vahor/n8n-kit": patch
+---
+
+Improve assignment type validation in Fields node
+
+Only include assignments with valid value types in the output type.

--- a/packages/n8n-kit/src/bundler/nodejs-function.ts
+++ b/packages/n8n-kit/src/bundler/nodejs-function.ts
@@ -86,19 +86,6 @@ export class NodejsFunction {
 		);
 	}
 
-	private getPackageJson() {
-		const packageJsonPath = `${this.props.projectRoot}/package.json`;
-		if (!fs.existsSync(packageJsonPath)) {
-			throw new Error("Could not find package.json");
-		}
-		return JSON.parse(fs.readFileSync(packageJsonPath, "utf8"));
-	}
-
-	public getDependencies() {
-		const packageJson = this.getPackageJson();
-		return Object.keys(packageJson.dependencies ?? {});
-	}
-
 	public getBundledFile(outDir: string) {
 		const entrypoint = path.basename(this.entrypoint);
 		return path.join(outDir, entrypoint.replace(".ts", ".js"));

--- a/packages/n8n-kit/src/nodes/fields.ts
+++ b/packages/n8n-kit/src/nodes/fields.ts
@@ -1,11 +1,7 @@
 import type { Type } from "arktype";
 import type { SetV2NodeParameters } from "../generated/nodes/SetV2";
 import { SetV2 as _Fields } from "../generated/nodes-impl/SetV2";
-import type {
-	ErrorMessage,
-	ToString,
-	UnionToIntersection,
-} from "../utils/types";
+import type { UnionToIntersection } from "../utils/types";
 import { ExpressionBuilder } from "../workflow";
 import type { NodeProps } from "./node";
 
@@ -37,16 +33,14 @@ type IsValidValue<T extends Type, V> = V extends ExpressionBuilder<
 		? true
 		: false;
 
-type AssignmentsToObject<T extends readonly { name: string; type: Type }[]> = {
+type AssignmentsToObject<T extends readonly Assignment[]> = {
 	[K in keyof T]: T[K] extends {
 		name: infer N extends string;
 		type: infer T extends Type;
 		value: infer V;
 	}
 		? {
-				[K in N]: IsValidValue<T, V> extends true
-					? T["infer"]
-					: ErrorMessage<`Expected type '${ToString<T["infer"]>}' but got '${ToString<V>}'.`>;
+				[K in N]: IsValidValue<T, V> extends true ? T["infer"] : never;
 			}
 		: never;
 }[number];

--- a/packages/n8n-kit/src/utils/types.ts
+++ b/packages/n8n-kit/src/utils/types.ts
@@ -58,31 +58,22 @@ type FormatWithPrefix<
 
 type NumberStr = `${number}`;
 
-export type JoinKeys<T, OnlyLeaf = false, Prefix extends string = ""> = {
+export type JoinKeys<T, Prefix extends string = ""> = {
 	[K in keyof T]: T[K] extends Function
 		? `${Prefix}${Extract<K, string>}`
 		: T[K] extends Primitive | Date
 			? FormatWithPrefix<Extract<K, string>, Prefix>
 			: T[K] extends Array<infer U>
 				?
-						| (OnlyLeaf extends true
-								? never
-								: FormatWithPrefix<Extract<K, string>, Prefix>)
+						| FormatWithPrefix<Extract<K, string>, Prefix>
 						| JoinKeys<
 								U,
-								OnlyLeaf,
 								`${FormatWithPrefix<Extract<K, string>, Prefix>}[${NumberStr}]`
 						  >
 				: T[K] extends object
 					?
-							| (OnlyLeaf extends true
-									? never
-									: FormatWithPrefix<Extract<K, string>, Prefix>)
-							| JoinKeys<
-									T[K],
-									OnlyLeaf,
-									FormatWithPrefix<Extract<K, string>, Prefix>
-							  >
+							| FormatWithPrefix<Extract<K, string>, Prefix>
+							| JoinKeys<T[K], FormatWithPrefix<Extract<K, string>, Prefix>>
 					: FormatWithPrefix<Extract<K, string>, Prefix>;
 }[keyof T];
 
@@ -150,15 +141,3 @@ export type ZeroWidthSpace = typeof zeroWidthSpace;
 export type ErrorMessage<message extends string = string> =
 	`${message}${ZeroWidthSpace}`;
 // end
-
-export type ToString<T> = T extends string | number | boolean | undefined | null
-	? `${T}`
-	: T extends Function
-		? "function"
-		: T extends Array<any>
-			? `Array`
-			: T extends object
-				? "object"
-				: T extends any
-					? "any"
-					: "unknown";

--- a/packages/n8n-kit/src/utils/types.ts
+++ b/packages/n8n-kit/src/utils/types.ts
@@ -150,3 +150,15 @@ export type ZeroWidthSpace = typeof zeroWidthSpace;
 export type ErrorMessage<message extends string = string> =
 	`${message}${ZeroWidthSpace}`;
 // end
+
+export type ToString<T> = T extends string | number | boolean | undefined | null
+	? `${T}`
+	: T extends Function
+		? "function"
+		: T extends Array<any>
+			? `Array`
+			: T extends object
+				? "object"
+				: T extends any
+					? "any"
+					: "unknown";


### PR DESCRIPTION
 https://github.com/Vahor/n8n-kit/issues/60

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Improvements
  - Fields node now validates assignment value types more strictly, only emitting assignments with valid types and improved expression handling.

- Refactor
  - Simplified TypeScript key-path typings for more consistent path generation; may impact advanced type consumers.
  - Removed deprecated dependency introspection from the bundling API.

- Chores
  - Prepared a patch release for @vahor/n8n-kit.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->