### PR TITLE
set default properties in HttpRequest

### DIFF
--- a/.changeset/cyan-rockets-care.md
+++ b/.changeset/cyan-rockets-care.md
@@ -1,0 +1,7 @@
+---
+"@vahor/n8n-kit": patch
+---
+
+set default values for `sendBody`, `sendHeaders` and `specifyBody` in HttpRequest based on the other parameters
+
+Example if we set `jsonBody` this automatically sets `specifyBody` to `json` and `sendBody` to `true`.

--- a/examples/code-http-anthropic/index.ts
+++ b/examples/code-http-anthropic/index.ts
@@ -106,9 +106,7 @@ const workflow = new Workflow("my-workflow", {
 								url: "https://api.anthropic.com/v1/messages",
 								authentication: "predefinedCredentialType",
 								nodeCredentialType: "anthropicApi",
-								specifyBody: "json",
-								sendBody: true,
-								sendHeaders: true,
+
 								headerParameters: {
 									parameters: [
 										{

--- a/examples/code-http-anthropic/index.ts
+++ b/examples/code-http-anthropic/index.ts
@@ -57,8 +57,6 @@ const workflow = new Workflow("my-workflow", {
 					url: "https://httpbin.org/post",
 					authentication: "genericCredentialType",
 					genericAuthType: "httpCustomAuth",
-					specifyBody: "json",
-					sendBody: true,
 					jsonBody: JsonExpression.from({
 						events: [
 							{

--- a/packages/n8n-kit/src/nodes/http-request.ts
+++ b/packages/n8n-kit/src/nodes/http-request.ts
@@ -33,6 +33,26 @@ export class HttpRequest<
 		override props: P,
 	) {
 		super(id, props);
+		this.props.parameters = this.setDefaultParameters(props.parameters);
+	}
+
+	private setDefaultParameters(
+		parameters: HttpRequestProps["parameters"],
+	): HttpRequestProps["parameters"] {
+		const result = { ...parameters };
+
+		// If jsonBody is present, set defaults for sendBody and specifyBody
+		if (result.jsonBody != null) {
+			if (result.sendBody === undefined) result.sendBody = true;
+			if (result.specifyBody === undefined) result.specifyBody = "json";
+		}
+
+		// If headerParameters is present, set default for sendHeaders
+		if (result.headerParameters != null) {
+			if (result.sendHeaders === undefined) result.sendHeaders = true;
+		}
+
+		return result;
 	}
 
 	override "~validate"(): void {


### PR DESCRIPTION
fix https://github.com/Vahor/n8n-kit/issues/64

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - HttpRequest now auto-derives defaults: setting jsonBody enables sendBody and sets specifyBody to json; setting headerParameters enables sendHeaders. Reduces manual configuration.
- Chores
  - Added changeset for a patch release.
  - Updated examples to remove redundant send flags in line with new defaults.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->