### PR TITLE
add jsdoc comment on all outputSchema

### DIFF
--- a/packages/n8n-kit/scripts/copy-comments.ts
+++ b/packages/n8n-kit/scripts/copy-comments.ts
@@ -1,0 +1,41 @@
+import fs from "node:fs";
+import spawn from "nano-spawn";
+
+const COMMENT_MAPPINGS = {
+	OutputSchema: `Output schema is only a TypeScript typedef used for compile-time typing.
+ * It does NOT perform runtime validation. 
+ * Use \`Code\` nodes or \`If\` nodes if you need to enforce structure at runtime.`,
+	InputSchema: `Input schema is only a TypeScript typedef used for compile-time typing.
+ * It does NOT perform runtime validation. 
+ * Use \`Code\` nodes or \`If\` nodes if you need to enforce structure at runtime.`,
+};
+
+export const process = async () => {
+	const filesToChange = await spawn("find", [
+		"dist",
+		"-type",
+		"f",
+		"-name",
+		"*.d.[cm]ts",
+		"-exec",
+		"grep",
+		"-H",
+		"-l",
+		"{@replace",
+		"{}",
+		";",
+	]);
+	const allFiles = filesToChange.stdout.split("\n");
+
+	for (const [key, value] of Object.entries(COMMENT_MAPPINGS)) {
+		for (const file of allFiles) {
+			// Skill issue I wanted to use sed but escaping was hard :(
+			const content = fs.readFileSync(file, "utf8");
+			const newContent = content.replaceAll(`{@replace ${key}}`, value);
+			if (newContent !== content) {
+				fs.writeFileSync(file, newContent);
+				console.log(`Replaced ${key} in ${file}`);
+			}
+		}
+	}
+};

--- a/packages/n8n-kit/src/nodes/code.ts
+++ b/packages/n8n-kit/src/nodes/code.ts
@@ -7,6 +7,8 @@ import type { IsNever } from "../utils/types";
 import type { NodeProps } from "./node";
 
 export interface CodeProps extends NodeProps {
+	/** {@replace OutputSchema} */
+	outputSchema?: Type;
 	parameters:
 		| (Omit<CodeNodeParameters, "language" | "jsCode" | "pythonCode"> & {
 				language?: "javaScript";
@@ -18,7 +20,6 @@ export interface CodeProps extends NodeProps {
 				pythonCode: string | PythonFunction;
 				jsCode?: never;
 		  });
-	outputSchema?: Type;
 }
 
 // @ts-expect-error: we override the parameters type

--- a/packages/n8n-kit/src/nodes/http-request.ts
+++ b/packages/n8n-kit/src/nodes/http-request.ts
@@ -9,6 +9,8 @@ import type { IsNever, RequireFields } from "../utils/types";
 
 type HttpRequestProps = Omit<HttpRequestV3Props, "parameters"> & {
 	parameters: RequireFields<HttpRequestV3Props["parameters"], "method" | "url">;
+} & {
+	/** {@replace OutputSchema} */
 	outputSchema?: Type;
 };
 

--- a/packages/n8n-kit/src/nodes/webhook.ts
+++ b/packages/n8n-kit/src/nodes/webhook.ts
@@ -10,9 +10,13 @@ interface WebhookBaseProps
 export interface WebhookProps extends NodeProps {
 	parameters: WebhookBaseProps;
 	outputSchema?: {
+		/** {@replace OutputSchema} */
 		params?: Type;
+		/** {@replace OutputSchema} */
 		headers?: Type;
+		/** {@replace OutputSchema} */
 		body?: Type;
+		/** {@replace OutputSchema} */
 		query?: Type;
 	};
 }

--- a/packages/n8n-kit/src/workflow/workflow.ts
+++ b/packages/n8n-kit/src/workflow/workflow.ts
@@ -23,8 +23,6 @@ type WorkflowDefinitionProvider<Input extends Type, Output extends Type, T> =
 
 export interface WorkflowProps<Input extends Type, Output extends Type> {
 	name?: string;
-	inputSchema?: Input;
-	outputSchema?: Output;
 	definition: WorkflowDefinitionProvider<
 		Input,
 		Output,
@@ -32,6 +30,11 @@ export interface WorkflowProps<Input extends Type, Output extends Type> {
 	>;
 	tags?: string[] | undefined;
 	active?: boolean;
+
+	/** {@replace OutputSchema} */
+	outputSchema?: Output;
+	/** {@replace InputSchema} */
+	inputSchema?: Input;
 
 	settings?: {
 		/**

--- a/packages/n8n-kit/tsconfig.json
+++ b/packages/n8n-kit/tsconfig.json
@@ -23,6 +23,7 @@
 	},
 	"include": [
 		"src/**/*.ts",
+		"scripts/**/*.ts",
 		"tests/**/*.ts",
 		"vendor/n8n/packages/nodes-base/**/*.ts",
 		"generated/credentials/**/*.ts",

--- a/packages/n8n-kit/tsdown.config.ts
+++ b/packages/n8n-kit/tsdown.config.ts
@@ -1,4 +1,5 @@
 import { defineConfig } from "tsdown";
+import { process } from "./scripts/copy-comments.ts";
 
 export const input = [
 	"src/index.ts",
@@ -27,4 +28,9 @@ export default defineConfig({
 		dts: ctx.format === "cjs" ? ".d.cts" : ".d.mts",
 		js: ctx.format === "cjs" ? ".cjs" : ".mjs",
 	}),
+	hooks: {
+		"build:done": async () => {
+			await process();
+		},
+	},
 });


### PR DESCRIPTION
fix: https://github.com/Vahor/n8n-kit/issues/65


I did not want to copy-paste the same comment everywhere so I added a `copy-comments` script that replace the comment in dist code.

Bit of skill issue, I wanted to use sed but with multiline / escaping I used a js script to replace the content 🙃