### PR TITLE
add watch mode

### DIFF
--- a/.changeset/yellow-planes-wash.md
+++ b/.changeset/yellow-planes-wash.md
@@ -1,0 +1,5 @@
+---
+"@vahor/n8n-kit-cli": patch
+---
+
+Add `--watch` flag on build and deploy commands

--- a/bun.lock
+++ b/bun.lock
@@ -9,7 +9,7 @@
         "@changesets/cli": "^2.29.6",
         "@types/bun": "^1.2.21",
         "husky": "^9.1.7",
-        "lint-staged": "^16.1.5",
+        "lint-staged": "^16.1.6",
         "pkg-pr-new": "^0.0.58",
         "typedoc": "^0.28.12",
         "typedoc-theme-oxide": "^0.2.0",
@@ -87,7 +87,6 @@
         "yargs": "^18.0.0",
       },
       "devDependencies": {
-        "@types/chokidar": "^2.1.7",
         "@types/yargs": "^17.0.33",
         "tsdown": "catalog:",
         "typescript": "catalog:",
@@ -916,8 +915,6 @@
     "@types/bun": ["@types/bun@1.2.21", "", { "dependencies": { "bun-types": "1.2.21" } }, "sha512-NiDnvEqmbfQ6dmZ3EeUO577s4P5bf4HCTXtI6trMc6f6RzirY5IrF3aIookuSpyslFzrnvv2lmEWv5HyC1X79A=="],
 
     "@types/caseless": ["@types/caseless@0.12.5", "", {}, "sha512-hWtVTC2q7hc7xZ/RLbxapMvDMgUnDvKvMOpKal4DrMyfGBUfB1oKaZlIRr6mJL+If3bAP6sV/QneGzF6tJjZDg=="],
-
-    "@types/chokidar": ["@types/chokidar@2.1.7", "", { "dependencies": { "chokidar": "*" } }, "sha512-A7/MFHf6KF7peCzjEC1BBTF8jpmZTokb3vr/A0NxRGfwRLK3Ws+Hq6ugVn6cJIMfM6wkCak/aplWrxbTcu8oig=="],
 
     "@types/connect": ["@types/connect@3.4.38", "", { "dependencies": { "@types/node": "*" } }, "sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -80,12 +80,14 @@
         "@vahor/n8n-kit": "workspace:*",
         "arktype": "catalog:",
         "chalk": "catalog:",
+        "chokidar": "^4.0.3",
         "codemaker": "^1.113.0",
         "nano-spawn": "catalog:",
         "table": "^6.9.0",
         "yargs": "^18.0.0",
       },
       "devDependencies": {
+        "@types/chokidar": "^2.1.7",
         "@types/yargs": "^17.0.33",
         "tsdown": "catalog:",
         "typescript": "catalog:",
@@ -114,6 +116,13 @@
         "typescript": "catalog:",
       },
     },
+  },
+  "catalog": {
+    "arktype": "^2.1.20",
+    "chalk": "^5.6.0",
+    "nano-spawn": "^1.0.2",
+    "tsdown": "^0.14.1",
+    "typescript": "^5.9.2",
   },
   "packages": {
     "@actions/core": ["@actions/core@1.11.1", "", { "dependencies": { "@actions/exec": "^1.1.1", "@actions/http-client": "^2.0.1" } }, "sha512-hXJCSrkwfA46Vd9Z3q4cpEpHB1rL5NG04+/rbqW9d3+CSvtB1tYe8UTpAlixa1vj0m/ULglfEK2UKxMGxCxv5A=="],
@@ -907,6 +916,8 @@
     "@types/bun": ["@types/bun@1.2.21", "", { "dependencies": { "bun-types": "1.2.21" } }, "sha512-NiDnvEqmbfQ6dmZ3EeUO577s4P5bf4HCTXtI6trMc6f6RzirY5IrF3aIookuSpyslFzrnvv2lmEWv5HyC1X79A=="],
 
     "@types/caseless": ["@types/caseless@0.12.5", "", {}, "sha512-hWtVTC2q7hc7xZ/RLbxapMvDMgUnDvKvMOpKal4DrMyfGBUfB1oKaZlIRr6mJL+If3bAP6sV/QneGzF6tJjZDg=="],
+
+    "@types/chokidar": ["@types/chokidar@2.1.7", "", { "dependencies": { "chokidar": "*" } }, "sha512-A7/MFHf6KF7peCzjEC1BBTF8jpmZTokb3vr/A0NxRGfwRLK3Ws+Hq6ugVn6cJIMfM6wkCak/aplWrxbTcu8oig=="],
 
     "@types/connect": ["@types/connect@3.4.38", "", { "dependencies": { "@types/node": "*" } }, "sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -1847,9 +1847,9 @@
 
     "linkify-it": ["linkify-it@5.0.0", "", { "dependencies": { "uc.micro": "^2.0.0" } }, "sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ=="],
 
-    "lint-staged": ["lint-staged@16.1.5", "", { "dependencies": { "chalk": "^5.5.0", "commander": "^14.0.0", "debug": "^4.4.1", "lilconfig": "^3.1.3", "listr2": "^9.0.1", "micromatch": "^4.0.8", "nano-spawn": "^1.0.2", "pidtree": "^0.6.0", "string-argv": "^0.3.2", "yaml": "^2.8.1" }, "bin": { "lint-staged": "bin/lint-staged.js" } }, "sha512-uAeQQwByI6dfV7wpt/gVqg+jAPaSp8WwOA8kKC/dv1qw14oGpnpAisY65ibGHUGDUv0rYaZ8CAJZ/1U8hUvC2A=="],
+    "lint-staged": ["lint-staged@16.1.6", "", { "dependencies": { "chalk": "^5.6.0", "commander": "^14.0.0", "debug": "^4.4.1", "lilconfig": "^3.1.3", "listr2": "^9.0.3", "micromatch": "^4.0.8", "nano-spawn": "^1.0.2", "pidtree": "^0.6.0", "string-argv": "^0.3.2", "yaml": "^2.8.1" }, "bin": { "lint-staged": "bin/lint-staged.js" } }, "sha512-U4kuulU3CKIytlkLlaHcGgKscNfJPNTiDF2avIUGFCv7K95/DCYQ7Ra62ydeRWmgQGg9zJYw2dzdbztwJlqrow=="],
 
-    "listr2": ["listr2@9.0.1", "", { "dependencies": { "cli-truncate": "^4.0.0", "colorette": "^2.0.20", "eventemitter3": "^5.0.1", "log-update": "^6.1.0", "rfdc": "^1.4.1", "wrap-ansi": "^9.0.0" } }, "sha512-SL0JY3DaxylDuo/MecFeiC+7pedM0zia33zl0vcjgwcq1q1FWWF1To9EIauPbl8GbMCU0R2e0uJ8bZunhYKD2g=="],
+    "listr2": ["listr2@9.0.3", "", { "dependencies": { "cli-truncate": "^4.0.0", "colorette": "^2.0.20", "eventemitter3": "^5.0.1", "log-update": "^6.1.0", "rfdc": "^1.4.1", "wrap-ansi": "^9.0.0" } }, "sha512-0aeh5HHHgmq1KRdMMDHfhMWQmIT/m7nRDTlxlFqni2Sp0had9baqsjJRvDGdlvgd6NmPE0nPloOipiQJGFtTHQ=="],
 
     "locate-path": ["locate-path@5.0.0", "", { "dependencies": { "p-locate": "^4.1.0" } }, "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g=="],
 

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
 		"@changesets/cli": "^2.29.6",
 		"@types/bun": "^1.2.21",
 		"husky": "^9.1.7",
-		"lint-staged": "^16.1.5",
+		"lint-staged": "^16.1.6",
 		"pkg-pr-new": "^0.0.58",
 		"typedoc": "^0.28.12",
 		"typedoc-theme-oxide": "^0.2.0"

--- a/packages/n8n-cli/README.md
+++ b/packages/n8n-cli/README.md
@@ -101,11 +101,25 @@ bunx @vahor/n8n build [options]
 
 **Options:**
 - `--indent <number>` - Indent JSON files (default: 0)
+- `--sort` - Sort keys alphabetically, useful to compare JSON files
+- `--watch [path]` - Watch for changes and rebuild automatically. Pass a path to watch a specific folder, or leave empty to watch the entrypoint
 
-**Example:**
+**Examples:**
 ```sh
+# Regular build with indentation
 bunx @vahor/n8n build --indent 2
+
+# Watch mode - watches the entrypoint file
+bunx @vahor/n8n build --watch --yes
+
+# Watch mode - watches a specific directory
+bunx @vahor/n8n build --yes --watch src/
 ```
+
+**Watch Mode:**
+- Automatically rebuilds when files change
+- Uses a 300ms debounce to avoid excessive rebuilds
+- Press `Ctrl+C` to stop watching
 
 ### deploy
 
@@ -117,6 +131,7 @@ bunx @vahor/n8n deploy [options]
 
 **Options:**
 - `--merge` - Do not overwrite nodes position in existing workflows (default: true)
+- `--watch [path]` - Watch for changes and redeploy automatically. Pass a path to watch a specific folder, or leave empty to watch the entrypoint
 
 **Workflow Matching:**
 
@@ -126,10 +141,22 @@ bunx @vahor/n8n deploy [options]
 
 **Note:** The CLI will never delete workflows or ids. If you want to delete a workflow that is no longer defined in your code, you can do it manually in n8n.
 
-**Example:**
+**Examples:**
 ```sh
+# Regular deploy
 bunx @vahor/n8n deploy --yes
+
+# Watch mode - watches the entrypoint file and redeploys on changes
+bunx @vahor/n8n deploy --watch --yes
+
+# Watch mode - watches a specific directory
+bunx @vahor/n8n deploy --watch src/ --yes
 ```
+
+**Watch Mode:**
+- Automatically redeploys when files change
+- Uses a 300ms debounce to avoid excessive deploys
+- Press `Ctrl+C` to stop watching
 
 ### diff
 

--- a/packages/n8n-cli/package.json
+++ b/packages/n8n-cli/package.json
@@ -37,12 +37,14 @@
 		"@vahor/n8n-kit": "workspace:*",
 		"arktype": "catalog:",
 		"chalk": "catalog:",
+		"chokidar": "^4.0.3",
 		"codemaker": "^1.113.0",
 		"nano-spawn": "catalog:",
 		"table": "^6.9.0",
 		"yargs": "^18.0.0"
 	},
 	"devDependencies": {
+		"@types/chokidar": "^2.1.7",
 		"@types/yargs": "^17.0.33",
 		"tsdown": "catalog:",
 		"typescript": "catalog:"

--- a/packages/n8n-cli/package.json
+++ b/packages/n8n-cli/package.json
@@ -44,7 +44,6 @@
 		"yargs": "^18.0.0"
 	},
 	"devDependencies": {
-		"@types/chokidar": "^2.1.7",
 		"@types/yargs": "^17.0.33",
 		"tsdown": "catalog:",
 		"typescript": "catalog:"

--- a/packages/n8n-cli/src/utils/watch.ts
+++ b/packages/n8n-cli/src/utils/watch.ts
@@ -1,0 +1,82 @@
+import * as path from "node:path";
+import logger from "@vahor/n8n-kit/logger";
+import chalk from "chalk";
+import chokidar from "chokidar";
+
+export type WatchOptions = {
+	watch?: string;
+};
+
+export interface WatchConfig {
+	/** Function to execute when files change */
+	callback: () => Promise<unknown>;
+	/** Description of the action being performed (e.g., "rebuilding", "redeploying") */
+	actionName: string;
+	/** Success message to show after rebuild (e.g., "Rebuild", "Redeploy") */
+	successName: string;
+}
+
+export const setupWatch = async (
+	config: WatchConfig,
+	entrypoint: string,
+): Promise<void> => {
+	const { callback, actionName, successName } = config;
+
+	const watchPath = path.resolve(process.cwd(), entrypoint);
+
+	logger.log(`${chalk.green("Watching")} ${entrypoint} for changes...`);
+	logger.log(`Press ${chalk.bold("Ctrl+C")} to stop watching`);
+
+	let isProcessing = false;
+	let timeoutId: NodeJS.Timeout | null = null;
+
+	const rebuild = async () => {
+		if (isProcessing) return;
+		isProcessing = true;
+
+		try {
+			console.log();
+			logger.log(`${chalk.yellow("Change detected")} - ${actionName}...`);
+			console.log();
+			await callback();
+			console.log();
+			logger.log(`${chalk.green("✓")} ${successName} complete`);
+		} catch (error) {
+			console.log();
+			logger.error(`${successName} failed: ${error}`);
+		} finally {
+			isProcessing = false;
+		}
+	};
+
+	const debouncedRebuild = () => {
+		if (timeoutId) clearTimeout(timeoutId);
+		timeoutId = setTimeout(rebuild, 300);
+	};
+
+	// Watch for changes
+	const watcher = chokidar.watch(watchPath, {
+		ignored: [
+			"**/node_modules/**",
+			"**/.git/**",
+			"**/dist/**",
+			"**/workflows/*.json",
+		],
+		ignoreInitial: true,
+		persistent: true,
+	});
+
+	watcher.on("change", debouncedRebuild);
+	watcher.on("add", debouncedRebuild);
+	watcher.on("unlink", debouncedRebuild);
+
+	const cleanup = () => {
+		watcher.close();
+		if (timeoutId) clearTimeout(timeoutId);
+		logger.log(`\n${chalk.yellow("Stopped watching")}`);
+		process.exit(0);
+	};
+
+	process.on("SIGINT", cleanup);
+	process.on("SIGTERM", cleanup);
+};


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added --watch option to build and deploy commands for automatic rebuilds/redeploys on file changes.
  - Supports optional path to watch a specific directory or defaults to the entrypoint.
  - Includes debounce to prevent excessive runs and clear status messages.

- Documentation
  - Updated README with new --watch and --sort options, examples, and “Watch Mode” details for build and deploy.

- Chores
  - Added file-watching dependency and types.
  - Bumped lint-staged to ^16.1.6.
  - Added patch release entry.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->