### PR TITLE
replace ids in expressions by the node label

### DIFF
--- a/.changeset/moody-hands-rhyme.md
+++ b/.changeset/moody-hands-rhyme.md
@@ -1,0 +1,5 @@
+---
+"@vahor/n8n-kit": patch
+---
+
+fix: expression should use node label instead of node id

--- a/README.md
+++ b/README.md
@@ -77,17 +77,21 @@ new Workflow(app, "my-workflow", {
 			)
 			.next(({ $ }) =>
 				new If("if", {
-					combinator: "and",
-					conditions: [
-						{
-							operator: {
-								type: "string",
-								operation: "contains",
-							},
-							leftValue: $("json.classType").toExpression(),
-							rightValue: "C",
+					parameters: {
+						conditions: {
+							combinator: "and",
+							conditions: [
+								{
+									operator: {
+										type: "string",
+										operation: "contains",
+									},
+									leftValue: $("json.classType").toExpression(),
+									rightValue: "C",
+								},
+							],
 						},
-					],
+					},
 				})
 					.true(
 						new PostBin("PostBin(true)", {

--- a/examples/code-http-anthropic/index.ts
+++ b/examples/code-http-anthropic/index.ts
@@ -35,6 +35,7 @@ new Workflow(app, "my-workflow", {
 	definition: [
 		Chain.start(
 			new Webhook("webhook", {
+				label: "Webhook Trigger",
 				parameters: {
 					responseMode: "responseNode",
 					httpMethod: "GET",

--- a/examples/code-http-anthropic/n8n-kit/.bundle-py/INzyo95PUum4xEuiL9MT/generate-prompt.py
+++ b/examples/code-http-anthropic/n8n-kit/.bundle-py/INzyo95PUum4xEuiL9MT/generate-prompt.py
@@ -11,5 +11,5 @@ def handler(input):
     raise Exception("Invalid type")
 
 return handler({
-  "type": _('webhook').item.json.query.type
+  "type": _('@vahor/n8n-resolved_node_id@webhook').item.json.query.type
 });

--- a/examples/code-http-anthropic/n8n-kit/workflows/my-workflow.json
+++ b/examples/code-http-anthropic/n8n-kit/workflows/my-workflow.json
@@ -1,99 +1,99 @@
 {
-	"id": "1xE-9lGXWZxsp",
-	"name": "Webhook -> Analytics + Anthropic",
-	"nodes": [
-		{
-			"id": "webhook",
-			"name": "Webhook Trigger",
-			"type": "n8n-nodes-base.webhook",
-			"position": [60, 180],
-			"typeVersion": 2.1,
-			"parameters": {
-				"responseMode": "responseNode",
-				"httpMethod": "GET",
-				"path": "path-to-webhook"
-			}
-		},
-		{
-			"id": "send-to-analytics",
-			"name": "send-to-analytics",
-			"type": "n8n-nodes-base.httpRequest",
-			"position": [260, 60],
-			"typeVersion": 4.2,
-			"parameters": {
-				"method": "POST",
-				"url": "https://httpbin.org/post",
-				"authentication": "genericCredentialType",
-				"genericAuthType": "httpCustomAuth",
-				"jsonBody": "={\n  \"events\": [\n    {\n      \"user_id\": \"{{ $('Webhook Trigger').item.json.headers['cf-connecting-ip'] }}\",\n      \"event_type\": \"workflow_end\",\n      \"event_properties\": {\n        \"workflow_id\": \"{{ $workflow.id }}\"\n      }\n    }\n  ]\n}",
-				"sendBody": true,
-				"specifyBody": "json"
-			},
-			"credentials": { "httpCustomAuth": { "id": "hEQRwqdMuqRSHlXX" } },
-			"disabled": true
-		},
-		{
-			"id": "generate-prompt",
-			"name": "generate-prompt",
-			"type": "n8n-nodes-base.code",
-			"position": [260, 300],
-			"typeVersion": 2,
-			"parameters": {
-				"mode": "runOnceForEachItem",
-				"language": "python",
-				"pythonCode": "def handler(input):\n    if(input[\"type\"] == \"type1\"):\n        return {\n            \"prompt\": f\"Reply as if you were a gangster.\"\n        }\n    if(input[\"type\"] == \"type2\"):\n        return {\n            \"prompt\": f\"Reply as if you were a pirate.\"\n        }\n\n    raise Exception(\"Invalid type\")\n\nreturn handler({\n  \"type\": _('Webhook Trigger').item.json.query.type\n});"
-			}
-		},
-		{
-			"id": "send-to-anthropic",
-			"name": "send-to-anthropic",
-			"type": "n8n-nodes-base.httpRequest",
-			"position": [460, 300],
-			"typeVersion": 4.2,
-			"parameters": {
-				"method": "POST",
-				"url": "https://api.anthropic.com/v1/messages",
-				"authentication": "predefinedCredentialType",
-				"nodeCredentialType": "anthropicApi",
-				"headerParameters": {
-					"parameters": [{ "name": "anthropic-version", "value": "2023-06-01" }]
-				},
-				"jsonBody": "={\n  \"model\": \"claude-3-haiku-20240307\",\n  \"temperature\": 1,\n  \"max_tokens\": 200,\n  \"system\": [\n    {\n      \"text\": \"{{ $('generate-prompt').item.json.prompt }}\",\n      \"type\": \"text\"\n    }\n  ],\n  \"messages\": [\n    {\n      \"role\": \"user\",\n      \"content\": \"{{ $('Webhook Trigger').item.json.query.prompt }}\"\n    }\n  ]\n}",
-				"sendBody": true,
-				"specifyBody": "json",
-				"sendHeaders": true
-			},
-			"credentials": { "anthropicApi": { "id": "qtQFvIABHtrMfErE" } }
-		},
-		{
-			"id": "format-output",
-			"name": "format-output",
-			"type": "n8n-nodes-base.respondToWebhook",
-			"position": [660, 300],
-			"typeVersion": 1.5,
-			"parameters": {
-				"respondWith": "json",
-				"responseBody": "={\"message\":{{ $('send-to-anthropic').item.json.content.find((item) => item.type === 'text').text.toJsonString() }}}"
-			}
-		}
-	],
+	"active": true,
 	"connections": {
 		"Webhook Trigger": {
 			"main": [
 				[
-					{ "node": "send-to-analytics", "type": "main", "index": 0 },
-					{ "node": "generate-prompt", "type": "main", "index": 0 }
+					{ "index": 0, "node": "send-to-analytics", "type": "main" },
+					{ "index": 0, "node": "generate-prompt", "type": "main" }
 				]
 			]
 		},
 		"generate-prompt": {
-			"main": [[{ "node": "send-to-anthropic", "type": "main", "index": 0 }]]
+			"main": [[{ "index": 0, "node": "send-to-anthropic", "type": "main" }]]
 		},
 		"send-to-anthropic": {
-			"main": [[{ "node": "format-output", "type": "main", "index": 0 }]]
+			"main": [[{ "index": 0, "node": "format-output", "type": "main" }]]
 		}
 	},
+	"id": "1xE-9lGXWZxsp",
+	"name": "Webhook -> Analytics + Anthropic",
+	"nodes": [
+		{
+			"id": "format-output",
+			"name": "format-output",
+			"parameters": {
+				"respondWith": "json",
+				"responseBody": "={\"message\":{{ $('send-to-anthropic').item.json.content.find((item) => item.type === 'text').text.toJsonString() }}}"
+			},
+			"position": [660, 300],
+			"type": "n8n-nodes-base.respondToWebhook",
+			"typeVersion": 1.5
+		},
+		{
+			"id": "generate-prompt",
+			"name": "generate-prompt",
+			"parameters": {
+				"language": "python",
+				"mode": "runOnceForEachItem",
+				"pythonCode": "def handler(input):\n    if(input[\"type\"] == \"type1\"):\n        return {\n            \"prompt\": f\"Reply as if you were a gangster.\"\n        }\n    if(input[\"type\"] == \"type2\"):\n        return {\n            \"prompt\": f\"Reply as if you were a pirate.\"\n        }\n\n    raise Exception(\"Invalid type\")\n\nreturn handler({\n  \"type\": _('Webhook Trigger').item.json.query.type\n});"
+			},
+			"position": [260, 300],
+			"type": "n8n-nodes-base.code",
+			"typeVersion": 2
+		},
+		{
+			"credentials": { "httpCustomAuth": { "id": "hEQRwqdMuqRSHlXX" } },
+			"disabled": true,
+			"id": "send-to-analytics",
+			"name": "send-to-analytics",
+			"parameters": {
+				"authentication": "genericCredentialType",
+				"genericAuthType": "httpCustomAuth",
+				"jsonBody": "={\n  \"events\": [\n    {\n      \"user_id\": \"{{ $('Webhook Trigger').item.json.headers['cf-connecting-ip'] }}\",\n      \"event_type\": \"workflow_end\",\n      \"event_properties\": {\n        \"workflow_id\": \"{{ $workflow.id }}\"\n      }\n    }\n  ]\n}",
+				"method": "POST",
+				"sendBody": true,
+				"specifyBody": "json",
+				"url": "https://httpbin.org/post"
+			},
+			"position": [260, 60],
+			"type": "n8n-nodes-base.httpRequest",
+			"typeVersion": 4.2
+		},
+		{
+			"credentials": { "anthropicApi": { "id": "qtQFvIABHtrMfErE" } },
+			"id": "send-to-anthropic",
+			"name": "send-to-anthropic",
+			"parameters": {
+				"authentication": "predefinedCredentialType",
+				"headerParameters": {
+					"parameters": [{ "name": "anthropic-version", "value": "2023-06-01" }]
+				},
+				"jsonBody": "={\n  \"model\": \"claude-3-haiku-20240307\",\n  \"temperature\": 1,\n  \"max_tokens\": 200,\n  \"system\": [\n    {\n      \"text\": \"{{ $('generate-prompt').item.json.prompt }}\",\n      \"type\": \"text\"\n    }\n  ],\n  \"messages\": [\n    {\n      \"role\": \"user\",\n      \"content\": \"{{ $('Webhook Trigger').item.json.query.prompt }}\"\n    }\n  ]\n}",
+				"method": "POST",
+				"nodeCredentialType": "anthropicApi",
+				"sendBody": true,
+				"sendHeaders": true,
+				"specifyBody": "json",
+				"url": "https://api.anthropic.com/v1/messages"
+			},
+			"position": [460, 300],
+			"type": "n8n-nodes-base.httpRequest",
+			"typeVersion": 4.2
+		},
+		{
+			"id": "webhook",
+			"name": "Webhook Trigger",
+			"parameters": {
+				"httpMethod": "GET",
+				"path": "path-to-webhook",
+				"responseMode": "responseNode"
+			},
+			"position": [60, 180],
+			"type": "n8n-nodes-base.webhook",
+			"typeVersion": 2.1
+		}
+	],
 	"settings": {},
-	"active": true,
 	"tags": [{ "name": "@vahor/n8n-1xE-9lGXWZxsp" }]
 }

--- a/examples/code-http-anthropic/n8n-kit/workflows/my-workflow.json
+++ b/examples/code-http-anthropic/n8n-kit/workflows/my-workflow.json
@@ -1,99 +1,99 @@
 {
-	"active": true,
-	"connections": {
-		"generate-prompt": {
-			"main": [[{ "index": 0, "node": "send-to-anthropic", "type": "main" }]]
-		},
-		"send-to-anthropic": {
-			"main": [[{ "index": 0, "node": "format-output", "type": "main" }]]
-		},
-		"webhook": {
-			"main": [
-				[
-					{ "index": 0, "node": "send-to-analytics", "type": "main" },
-					{ "index": 0, "node": "generate-prompt", "type": "main" }
-				]
-			]
-		}
-	},
 	"id": "1xE-9lGXWZxsp",
 	"name": "Webhook -> Analytics + Anthropic",
 	"nodes": [
 		{
-			"id": "format-output",
-			"name": "format-output",
+			"id": "webhook",
+			"name": "Webhook Trigger",
+			"type": "n8n-nodes-base.webhook",
+			"position": [60, 180],
+			"typeVersion": 2.1,
 			"parameters": {
-				"respondWith": "json",
-				"responseBody": "={\"message\":{{ $('send-to-anthropic').item.json.content.find((item) => item.type === 'text').text.toJsonString() }}}"
+				"responseMode": "responseNode",
+				"httpMethod": "GET",
+				"path": "path-to-webhook"
+			}
+		},
+		{
+			"id": "send-to-analytics",
+			"name": "send-to-analytics",
+			"type": "n8n-nodes-base.httpRequest",
+			"position": [260, 60],
+			"typeVersion": 4.2,
+			"parameters": {
+				"method": "POST",
+				"url": "https://httpbin.org/post",
+				"authentication": "genericCredentialType",
+				"genericAuthType": "httpCustomAuth",
+				"jsonBody": "={\n  \"events\": [\n    {\n      \"user_id\": \"{{ $('Webhook Trigger').item.json.headers['cf-connecting-ip'] }}\",\n      \"event_type\": \"workflow_end\",\n      \"event_properties\": {\n        \"workflow_id\": \"{{ $workflow.id }}\"\n      }\n    }\n  ]\n}",
+				"sendBody": true,
+				"specifyBody": "json"
 			},
-			"position": [660, 300],
-			"type": "n8n-nodes-base.respondToWebhook",
-			"typeVersion": 1.5
+			"credentials": { "httpCustomAuth": { "id": "hEQRwqdMuqRSHlXX" } },
+			"disabled": true
 		},
 		{
 			"id": "generate-prompt",
 			"name": "generate-prompt",
-			"parameters": {
-				"language": "python",
-				"mode": "runOnceForEachItem",
-				"pythonCode": "def handler(input):\n    if(input[\"type\"] == \"type1\"):\n        return {\n            \"prompt\": f\"Reply as if you were a gangster.\"\n        }\n    if(input[\"type\"] == \"type2\"):\n        return {\n            \"prompt\": f\"Reply as if you were a pirate.\"\n        }\n\n    raise Exception(\"Invalid type\")\n\nreturn handler({\n  \"type\": _('webhook').item.json.query.type\n});"
-			},
-			"position": [260, 300],
 			"type": "n8n-nodes-base.code",
-			"typeVersion": 2
-		},
-		{
-			"credentials": { "httpCustomAuth": { "id": "hEQRwqdMuqRSHlXX" } },
-			"disabled": true,
-			"id": "send-to-analytics",
-			"name": "send-to-analytics",
+			"position": [260, 300],
+			"typeVersion": 2,
 			"parameters": {
-				"authentication": "genericCredentialType",
-				"genericAuthType": "httpCustomAuth",
-				"jsonBody": "={\n  \"events\": [\n    {\n      \"user_id\": \"{{ $('webhook').item.json.headers['cf-connecting-ip'] }}\",\n      \"event_type\": \"workflow_end\",\n      \"event_properties\": {\n        \"workflow_id\": \"{{ $workflow.id }}\"\n      }\n    }\n  ]\n}",
-				"method": "POST",
-				"sendBody": true,
-				"specifyBody": "json",
-				"url": "https://httpbin.org/post"
-			},
-			"position": [260, 60],
-			"type": "n8n-nodes-base.httpRequest",
-			"typeVersion": 4.2
+				"mode": "runOnceForEachItem",
+				"language": "python",
+				"pythonCode": "def handler(input):\n    if(input[\"type\"] == \"type1\"):\n        return {\n            \"prompt\": f\"Reply as if you were a gangster.\"\n        }\n    if(input[\"type\"] == \"type2\"):\n        return {\n            \"prompt\": f\"Reply as if you were a pirate.\"\n        }\n\n    raise Exception(\"Invalid type\")\n\nreturn handler({\n  \"type\": _('Webhook Trigger').item.json.query.type\n});"
+			}
 		},
 		{
-			"credentials": { "anthropicApi": { "id": "qtQFvIABHtrMfErE" } },
 			"id": "send-to-anthropic",
 			"name": "send-to-anthropic",
+			"type": "n8n-nodes-base.httpRequest",
+			"position": [460, 300],
+			"typeVersion": 4.2,
 			"parameters": {
+				"method": "POST",
+				"url": "https://api.anthropic.com/v1/messages",
 				"authentication": "predefinedCredentialType",
+				"nodeCredentialType": "anthropicApi",
 				"headerParameters": {
 					"parameters": [{ "name": "anthropic-version", "value": "2023-06-01" }]
 				},
-				"jsonBody": "={\n  \"model\": \"claude-3-haiku-20240307\",\n  \"temperature\": 1,\n  \"max_tokens\": 200,\n  \"system\": [\n    {\n      \"text\": \"{{ $('generate-prompt').item.json.prompt }}\",\n      \"type\": \"text\"\n    }\n  ],\n  \"messages\": [\n    {\n      \"role\": \"user\",\n      \"content\": \"{{ $('webhook').item.json.query.prompt }}\"\n    }\n  ]\n}",
-				"method": "POST",
-				"nodeCredentialType": "anthropicApi",
+				"jsonBody": "={\n  \"model\": \"claude-3-haiku-20240307\",\n  \"temperature\": 1,\n  \"max_tokens\": 200,\n  \"system\": [\n    {\n      \"text\": \"{{ $('generate-prompt').item.json.prompt }}\",\n      \"type\": \"text\"\n    }\n  ],\n  \"messages\": [\n    {\n      \"role\": \"user\",\n      \"content\": \"{{ $('Webhook Trigger').item.json.query.prompt }}\"\n    }\n  ]\n}",
 				"sendBody": true,
-				"sendHeaders": true,
 				"specifyBody": "json",
-				"url": "https://api.anthropic.com/v1/messages"
+				"sendHeaders": true
 			},
-			"position": [460, 300],
-			"type": "n8n-nodes-base.httpRequest",
-			"typeVersion": 4.2
+			"credentials": { "anthropicApi": { "id": "qtQFvIABHtrMfErE" } }
 		},
 		{
-			"id": "webhook",
-			"name": "webhook",
+			"id": "format-output",
+			"name": "format-output",
+			"type": "n8n-nodes-base.respondToWebhook",
+			"position": [660, 300],
+			"typeVersion": 1.5,
 			"parameters": {
-				"httpMethod": "GET",
-				"path": "path-to-webhook",
-				"responseMode": "responseNode"
-			},
-			"position": [60, 180],
-			"type": "n8n-nodes-base.webhook",
-			"typeVersion": 2.1
+				"respondWith": "json",
+				"responseBody": "={\"message\":{{ $('send-to-anthropic').item.json.content.find((item) => item.type === 'text').text.toJsonString() }}}"
+			}
 		}
 	],
+	"connections": {
+		"Webhook Trigger": {
+			"main": [
+				[
+					{ "node": "send-to-analytics", "type": "main", "index": 0 },
+					{ "node": "generate-prompt", "type": "main", "index": 0 }
+				]
+			]
+		},
+		"generate-prompt": {
+			"main": [[{ "node": "send-to-anthropic", "type": "main", "index": 0 }]]
+		},
+		"send-to-anthropic": {
+			"main": [[{ "node": "format-output", "type": "main", "index": 0 }]]
+		}
+	},
 	"settings": {},
+	"active": true,
 	"tags": [{ "name": "@vahor/n8n-1xE-9lGXWZxsp" }]
 }

--- a/examples/workflow-trigger/n8n-kit/workflows/workflow-trigger.json
+++ b/examples/workflow-trigger/n8n-kit/workflows/workflow-trigger.json
@@ -25,7 +25,7 @@
 					"__rl": true,
 					"cachedResultName": "Reusable workflow",
 					"mode": "list",
-					"value": "@vahor/n8n-_resolved_workflow_id@qL2pzX8jc7NDe"
+					"value": "@vahor/n8n-resolved_workflow_id@qL2pzX8jc7NDe"
 				},
 				"workflowInputs": {
 					"mappingMode": "defineBelow",
@@ -47,7 +47,7 @@
 					"__rl": true,
 					"cachedResultName": "Untitled",
 					"mode": "list",
-					"value": "@vahor/n8n-_resolved_workflow_id@qL2pzX8jc7NDe"
+					"value": "@vahor/n8n-resolved_workflow_id@qL2pzX8jc7NDe"
 				},
 				"workflowInputs": {
 					"mappingMode": "defineBelow",

--- a/packages/n8n-kit/README.md
+++ b/packages/n8n-kit/README.md
@@ -245,8 +245,7 @@ $("code.type").toExpression()
 // Results in: "={{ $('Some very long label').item.json.type }}"
 ```
 
-This helps having to type long names and having to changes everything when the node name changes.
-
+This avoids typing long names and changing references when the node label changes.
 ### Method Calls
 
 ```typescript

--- a/packages/n8n-kit/README.md
+++ b/packages/n8n-kit/README.md
@@ -228,6 +228,25 @@ $("['Node Name'].nested.property").toExpression()
 // Results in: "={{ $('Node Name').nested.property }}"
 ```
 
+Nodes ids are automatically replaced with the node label when workflow is built:
+
+```typescript
+const node = new Code("code", {
+	label: "Some very long label",
+	outputSchema: type({ type: "string" }),
+	parameters: {
+		jsCode: "...",
+	},
+});
+
+// and then
+$("code.type").toExpression()
+
+// Results in: "={{ $('Some very long label').item.json.type }}"
+```
+
+This helps having to type long names and having to changes everything when the node name changes.
+
 ### Method Calls
 
 ```typescript

--- a/packages/n8n-kit/README.md
+++ b/packages/n8n-kit/README.md
@@ -228,7 +228,7 @@ $("['Node Name'].nested.property").toExpression()
 // Results in: "={{ $('Node Name').nested.property }}"
 ```
 
-Nodes ids are automatically replaced with the node label when workflow is built:
+Node IDs are automatically replaced with the node label when the workflow is built:
 
 ```typescript
 const node = new Code("code", {

--- a/packages/n8n-kit/src/nodes/node.ts
+++ b/packages/n8n-kit/src/nodes/node.ts
@@ -90,6 +90,11 @@ export abstract class Node<
 	readonly [NODE_SYMBOL] = true;
 
 	/**
+	 * The node label
+	 */
+	public readonly label: string | undefined;
+
+	/**
 	 * The n8n node type identifier (e.g., 'n8n-nodes-base.httpRequest')
 	 */
 	protected abstract readonly type: string;
@@ -149,10 +154,12 @@ export abstract class Node<
 		this.props = props;
 		this.position = props?.position;
 		this.endStates = [this];
-	}
 
-	get label() {
-		return this.props?.label;
+		// escape quotes in label as they will be used in json and replaced manually
+		this.label = this.props?.label
+			?.replaceAll('"', '\\"')
+			.replaceAll("\\", "\\\\")
+			.replaceAll("'", "\\'");
 	}
 
 	/** @internal */

--- a/packages/n8n-kit/src/workflow/chain/expression-builder.ts
+++ b/packages/n8n-kit/src/workflow/chain/expression-builder.ts
@@ -1,3 +1,4 @@
+import { prefix } from "../../constants";
 import type {
 	ErrorMessage,
 	IsAny,
@@ -148,7 +149,8 @@ export class ExpressionBuilder<
 			if (nodeId === "json") {
 				baseExpression = `${this.options.prefix}json${path}`;
 			} else {
-				baseExpression = `${this.options.prefix}('${nodeId}').item.json${path}`;
+				// NOTE: n8n needs the node label and here we have a node id. So we need to replace it with the label at some point
+				baseExpression = `${this.options.prefix}('${RESOLVED_NODE_ID(nodeId)}').item.json${path}`;
 			}
 		} else {
 			throw new Error(`Unexpected mode: ${this.options.mode}`);
@@ -278,3 +280,8 @@ export type ExpressionBuilderProvider<CC extends ChainContext> = ReturnType<
 >;
 
 export type $Selector<T> = ExpressionBuilderProvider<ExtractChainContext<T>>;
+
+export const RESOLVED_NODE_ID_PREFIX = `${prefix}resolved_node_id@`;
+/** @internal */
+export const RESOLVED_NODE_ID = (nodeId: string) =>
+	`${RESOLVED_NODE_ID_PREFIX}${nodeId}`;

--- a/packages/n8n-kit/src/workflow/chain/expression-builder.ts
+++ b/packages/n8n-kit/src/workflow/chain/expression-builder.ts
@@ -282,6 +282,5 @@ export type ExpressionBuilderProvider<CC extends ChainContext> = ReturnType<
 export type $Selector<T> = ExpressionBuilderProvider<ExtractChainContext<T>>;
 
 export const RESOLVED_NODE_ID_PREFIX = `${prefix}resolved_node_id@`;
-/** @internal */
 export const RESOLVED_NODE_ID = (nodeId: string) =>
 	`${RESOLVED_NODE_ID_PREFIX}${nodeId}`;

--- a/packages/n8n-kit/src/workflow/workflow.ts
+++ b/packages/n8n-kit/src/workflow/workflow.ts
@@ -285,10 +285,10 @@ export class Workflow<
 		const ids = new Set<string>();
 		const allNodes = [...nodes, ...this.dynamicalyAddedNodes];
 		for (const node of allNodes) {
-			if (ids.has(node.id)) {
+			if (ids.has(node.getLabel())) {
 				throw new Error(`Node with id ${node.id} already exists`);
 			}
-			ids.add(node.id);
+			ids.add(node.getLabel());
 		}
 
 		const groups = this.dynamicalyAddedNodes.filter(

--- a/packages/n8n-kit/src/workflow/workflow.ts
+++ b/packages/n8n-kit/src/workflow/workflow.ts
@@ -4,7 +4,7 @@ import { getProjectSalt, prefix } from "../constants";
 import { Node } from "../nodes/node";
 import { WORKFLOW_SYMBOL } from "../symbols";
 import { shortHash, validateIdentifier } from "../utils/slugify";
-import { Placeholder, type State } from "./chain";
+import { Placeholder, RESOLVED_NODE_ID, type State } from "./chain";
 import { Chain } from "./chain/chain";
 import { Group } from "./group";
 import {
@@ -205,10 +205,31 @@ export class Workflow<
 			}
 		}
 
+		const builtNodes = await Promise.all(
+			layoutNodes.flatMap((node) => node.toNode()),
+		);
+
+		// HACK: As we have to replace the node id in label in each expression, we need to do it here
+		const resolvedNodes = builtNodes.map((node) => {
+			const nodeParameters = node.parameters;
+			if (nodeParameters) {
+				// using stringify to make it easier to replaceAll
+				let jsonParameters = JSON.stringify(nodeParameters);
+				for (const n of nodes) {
+					jsonParameters = jsonParameters.replaceAll(
+						RESOLVED_NODE_ID(n.id),
+						n.getLabel(),
+					);
+				}
+				node.parameters = JSON.parse(jsonParameters);
+			}
+			return node;
+		});
+
 		return {
 			id: this.getHashId()!,
 			name: this.getName(),
-			nodes: await Promise.all(layoutNodes.flatMap((node) => node.toNode())),
+			nodes: resolvedNodes,
 			connections: connections,
 			settings: this.props.settings ?? {},
 			active: this.props.active ?? false,
@@ -306,7 +327,7 @@ export type WorkflowDefinition = Awaited<ReturnType<Workflow["build"]>>;
 /** @internal */
 export const workflowTagId = (id: string) => `${prefix}${id}`;
 /** @internal */
-export const RESOLVED_WORKFLOW_ID_PREFIX = `${prefix}_resolved_workflow_id@`;
+export const RESOLVED_WORKFLOW_ID_PREFIX = `${prefix}resolved_workflow_id@`;
 /** @internal */
 export const RESOLVED_WORKFLOW_ID = (workflowId: string) =>
 	`${RESOLVED_WORKFLOW_ID_PREFIX}${workflowId}`;

--- a/packages/n8n-kit/tests/workflow/workflow.test.ts
+++ b/packages/n8n-kit/tests/workflow/workflow.test.ts
@@ -149,5 +149,25 @@ describe("Workflow", () => {
 				jsCode: "={{ $('Some very long label').item.json }}",
 			});
 		});
+
+		test.failing("fails when two nodes have the same id", async () => {
+			const app = new App();
+			const workflow = new Workflow(app, "test", {
+				definition: [Chain.start(new NoOp("a")).next(new NoOp("a"))],
+			});
+			workflow["~validate"]();
+		});
+
+		test.failing("fails when two nodes have the same id (label)", async () => {
+			const app = new App();
+			const workflow = new Workflow(app, "test", {
+				definition: [
+					Chain.start(new NoOp("a", { label: "a" })).next(
+						new NoOp("b", { label: "a" }),
+					),
+				],
+			});
+			workflow["~validate"]();
+		});
 	});
 });


### PR DESCRIPTION
fix: https://github.com/Vahor/n8n-kit/issues/94

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* Bug Fixes
  * Expressions now reference node labels instead of internal IDs, improving readability and resilience to renames.
* Documentation
  * Updated If node examples to use parameters.conditions.
  * Added example showing automatic replacement of node IDs with labels in expressions.
* Tests
  * Expanded coverage for expression label resolution, node-to-node expression wiring, and duplicate ID validation.
* Chores
  * Added changeset for patch release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->