### PR TITLE
ExecuteWorkflow remove the need to call toExpression on ExpressionBuilders

### DIFF
--- a/.changeset/long-foxes-strive.md
+++ b/.changeset/long-foxes-strive.md
@@ -1,0 +1,5 @@
+---
+"@vahor/n8n-kit": patch
+---
+
+In ExecuteWorkflow node, remove the need to call toExpression on simple ExpressionBuilders

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ new Workflow(app, "my-workflow", {
 										type: "string",
 										operation: "contains",
 									},
-									leftValue: $("json.classType").toExpression(),
+									leftValue: $("json.classType"),
 									rightValue: "C",
 								},
 							],

--- a/examples/nasa/index.ts
+++ b/examples/nasa/index.ts
@@ -62,7 +62,7 @@ new Workflow(app, "my-workflow", {
 										type: "string",
 										operation: "contains",
 									},
-									leftValue: $("json.classType").toExpression(),
+									leftValue: $("json.classType"),
 									rightValue: "C",
 								},
 							],

--- a/examples/workflow-trigger/index.ts
+++ b/examples/workflow-trigger/index.ts
@@ -56,7 +56,7 @@ new Workflow(app, "workflow-trigger", {
 							}),
 						}),
 						workflowInputs: {
-							a: $("json.hello").toExpression(),
+							a: $("json.hello"),
 						},
 					},
 				}),

--- a/packages/n8n-kit/src/nodes/execute-workflow.ts
+++ b/packages/n8n-kit/src/nodes/execute-workflow.ts
@@ -1,7 +1,13 @@
 import type { Type } from "arktype";
 import type { ExecuteWorkflowNodeParameters } from "../generated/nodes/ExecuteWorkflow";
 import { ExecuteWorkflow as _ExecuteWorkflow } from "../generated/nodes-impl/ExecuteWorkflow";
-import type { JsonExpression, Workflow } from "../workflow";
+import {
+	applyToExpression,
+	type ExpressionOrValue,
+	type JsonExpression,
+	resolveExpressionValue,
+	type Workflow,
+} from "../workflow";
 import type { ImportedWorkflow } from "../workflow/imported-workflow";
 import type { NodeProps } from "./node";
 
@@ -12,7 +18,10 @@ export interface ExecuteWorkflowProps<Input extends Type, Output extends Type>
 		"workflowId" | "source" | "workflowInputs"
 	> & {
 		workflow: Workflow<Input, Output> | ImportedWorkflow<Input, Output>;
-		workflowInputs: Input["infer"] | JsonExpression<Input["infer"]>;
+		workflowInputs:
+			| ExpressionOrValue<Input["infer"]>
+			| Record<string, unknown>
+			| JsonExpression<Input["infer"]>;
 	};
 }
 
@@ -31,7 +40,10 @@ export class ExecuteWorkflow<
 	private formatWorkflowInput() {
 		return {
 			mappingMode: "defineBelow",
-			value: this.props.parameters.workflowInputs,
+			value: applyToExpression(
+				this.props.parameters.workflowInputs,
+				resolveExpressionValue,
+			),
 			matchingColumns: [],
 			schema: [],
 		};


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Execute Workflow now accepts raw values or expressions for inputs, with automatic evaluation. This reduces boilerplate and simplifies configuring workflow inputs and conditions.
  - Simplified expression usage in conditions (no need for explicit wrapping) for clearer, more concise workflows.
- Documentation
  - Updated README and example workflows to demonstrate the simpler expression syntax and input configuration.
- Chores
  - Added changeset for a patch release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->