### PR TITLE
add a custom error message for .ts entrypoints

### DIFF
--- a/packages/n8n-cli/src/index.ts
+++ b/packages/n8n-cli/src/index.ts
@@ -82,6 +82,12 @@ yargsInstance
 		},
 	})
 	.fail((message, error) => {
+		if ("code" in error && error.code === "ERR_UNKNOWN_FILE_EXTENSION") {
+			logger.error(
+				"To use a .ts entrypoint, you need to use node >= 22.18 or bun",
+			);
+		}
+		console.log();
 		logger.error(message, error);
 		process.exit(1);
 	})

--- a/packages/n8n-cli/src/index.ts
+++ b/packages/n8n-cli/src/index.ts
@@ -82,7 +82,11 @@ yargsInstance
 		},
 	})
 	.fail((message, error) => {
-		if ("code" in error && error.code === "ERR_UNKNOWN_FILE_EXTENSION") {
+		if (
+			error instanceof Error &&
+			"code" in error &&
+			error.code === "ERR_UNKNOWN_FILE_EXTENSION"
+		) {
 			logger.error(
 				"To use a .ts entrypoint, you need to use node >= 22.18 or bun",
 			);


### PR DESCRIPTION
fix: https://github.com/Vahor/n8n-kit/issues/102

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CLI error messaging when launching a .ts entrypoint on an unsupported runtime. Users now receive a clear instruction to use Node.js ≥ 22.18 or Bun, followed by the original error for context, with improved readability. This change enhances troubleshooting during startup failures without altering normal command behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->